### PR TITLE
[Meta] Replace deprecated platformio.ini options

### DIFF
--- a/examples/_TEMPLATE/platformio.ini
+++ b/examples/_TEMPLATE/platformio.ini
@@ -21,7 +21,7 @@ build_unflags =
     -std=gnu++11
 monitor_flags = --filter=esp32_exception_decoder
 monitor_speed = 115200
-test_build_project_src = yes
+test_build_src = yes
 build_type = debug
 board_build.partitions = partitions.csv
 

--- a/examples/buttons-leds/platformio.ini
+++ b/examples/buttons-leds/platformio.ini
@@ -21,7 +21,7 @@ build_unflags =
     -std=gnu++11
 monitor_flags = --filter=esp32_exception_decoder
 monitor_speed = 115200
-test_build_project_src = yes
+test_build_src = yes
 build_type = debug
 
 [env:normal]

--- a/examples/buttons/platformio.ini
+++ b/examples/buttons/platformio.ini
@@ -21,7 +21,7 @@ build_unflags =
     -std=gnu++11
 monitor_flags = --filter=esp32_exception_decoder
 monitor_speed = 115200
-test_build_project_src = yes
+test_build_src = yes
 build_type = debug
 
 [env:normal]

--- a/examples/buzzer/platformio.ini
+++ b/examples/buzzer/platformio.ini
@@ -21,7 +21,7 @@ build_unflags =
     -std=gnu++11
 monitor_flags = --filter=esp32_exception_decoder
 monitor_speed = 115200
-test_build_project_src = yes
+test_build_src = yes
 build_type = debug
 
 [env:normal]

--- a/examples/cteni_souboru/platformio.ini
+++ b/examples/cteni_souboru/platformio.ini
@@ -21,7 +21,7 @@ build_unflags =
     -std=gnu++11
 monitor_flags = --filter=esp32_exception_decoder
 monitor_speed = 115200
-test_build_project_src = yes
+test_build_src = yes
 build_type = debug
 board_build.partitions = partitions.csv
 

--- a/examples/display/platformio.ini
+++ b/examples/display/platformio.ini
@@ -21,7 +21,7 @@ build_unflags =
     -std=gnu++11
 monitor_flags = --filter=esp32_exception_decoder
 monitor_speed = 115200
-test_build_project_src = yes
+test_build_src = yes
 build_type = debug
 
 [env:normal]

--- a/examples/game-pong/platformio.ini
+++ b/examples/game-pong/platformio.ini
@@ -21,7 +21,7 @@ build_unflags =
     -std=gnu++11
 monitor_flags = --filter=esp32_exception_decoder
 monitor_speed = 115200
-test_build_project_src = yes
+test_build_src = yes
 build_type = debug
 
 [env:normal]

--- a/examples/game-simon/platformio.ini
+++ b/examples/game-simon/platformio.ini
@@ -21,7 +21,7 @@ build_unflags =
     -std=gnu++11
 monitor_flags = --filter=esp32_exception_decoder
 monitor_speed = 115200
-test_build_project_src = yes
+test_build_src = yes
 build_type = debug
 
 [env:normal]

--- a/examples/graphics_01_generativeDesign/platformio.ini
+++ b/examples/graphics_01_generativeDesign/platformio.ini
@@ -22,7 +22,7 @@ build_unflags =
     -std=gnu++11
 monitor_flags = --filter=esp32_exception_decoder
 monitor_speed = 115200
-test_build_project_src = yes
+test_build_src = yes
 build_type = debug
 
 [env:normal]

--- a/examples/graphics_02_fire/platformio.ini
+++ b/examples/graphics_02_fire/platformio.ini
@@ -22,7 +22,7 @@ build_unflags =
     -std=gnu++11
 monitor_flags = --filter=esp32_exception_decoder
 monitor_speed = 115200
-test_build_project_src = yes
+test_build_src = yes
 build_type = debug
 
 [env:normal]

--- a/examples/graphics_03_knight_rider/platformio.ini
+++ b/examples/graphics_03_knight_rider/platformio.ini
@@ -22,7 +22,7 @@ build_unflags =
     -std=gnu++11
 monitor_flags = --filter=esp32_exception_decoder
 monitor_speed = 115200
-test_build_project_src = yes
+test_build_src = yes
 build_type = debug
 
 [env:normal]

--- a/examples/network-room/platformio.ini
+++ b/examples/network-room/platformio.ini
@@ -21,7 +21,7 @@ build_unflags =
     -std=gnu++11
 monitor_flags = --filter=esp32_exception_decoder
 monitor_speed = 115200
-test_build_project_src = yes
+test_build_src = yes
 build_type = debug
 board_build.partitions = partitions.csv
 

--- a/examples/rbcontroller-basic/platformio.ini
+++ b/examples/rbcontroller-basic/platformio.ini
@@ -21,7 +21,7 @@ build_unflags =
     -std=gnu++11
 monitor_flags = --filter=esp32_exception_decoder
 monitor_speed = 115200
-test_build_project_src = yes
+test_build_src = yes
 build_type = debug
 board_build.partitions = partitions.csv
 

--- a/examples/sachovnice/platformio.ini
+++ b/examples/sachovnice/platformio.ini
@@ -21,7 +21,7 @@ build_unflags =
     -std=gnu++11
 monitor_flags = --filter=esp32_exception_decoder
 monitor_speed = 115200
-test_build_project_src = yes
+test_build_src = yes
 build_type = debug
 
 [env:normal]

--- a/examples/snake_01_dot_move/platformio.ini
+++ b/examples/snake_01_dot_move/platformio.ini
@@ -21,7 +21,7 @@ build_unflags =
     -std=gnu++11
 monitor_flags = --filter=esp32_exception_decoder
 monitor_speed = 115200
-test_build_project_src = yes
+test_build_src = yes
 build_type = debug
 
 [env:normal]

--- a/examples/snake_01_dot_move_infin/platformio.ini
+++ b/examples/snake_01_dot_move_infin/platformio.ini
@@ -21,7 +21,7 @@ build_unflags =
     -std=gnu++11
 monitor_flags = --filter=esp32_exception_decoder
 monitor_speed = 115200
-test_build_project_src = yes
+test_build_src = yes
 build_type = debug
 
 [env:normal]

--- a/examples/snake_02_change_direction/platformio.ini
+++ b/examples/snake_02_change_direction/platformio.ini
@@ -21,7 +21,7 @@ build_unflags =
     -std=gnu++11
 monitor_flags = --filter=esp32_exception_decoder
 monitor_speed = 115200
-test_build_project_src = yes
+test_build_src = yes
 build_type = debug
 
 [env:normal]

--- a/examples/snake_03_tail/platformio.ini
+++ b/examples/snake_03_tail/platformio.ini
@@ -21,7 +21,7 @@ build_unflags =
     -std=gnu++11
 monitor_flags = --filter=esp32_exception_decoder
 monitor_speed = 115200
-test_build_project_src = yes
+test_build_src = yes
 build_type = debug
 
 [env:normal]

--- a/examples/statusBar/platformio.ini
+++ b/examples/statusBar/platformio.ini
@@ -21,7 +21,7 @@ build_unflags =
     -std=gnu++11
 monitor_flags = --filter=esp32_exception_decoder
 monitor_speed = 115200
-test_build_project_src = yes
+test_build_src = yes
 build_type = debug
 
 [env:normal]

--- a/platformio.ini
+++ b/platformio.ini
@@ -21,7 +21,7 @@ build_unflags =
     -std=gnu++11
 monitor_flags = --filter=esp32_exception_decoder
 monitor_speed = 115200
-test_build_project_src = yes
+test_build_src = yes
 build_type = debug
 
 [env:normal]


### PR DESCRIPTION
Renamed all occurrences of the `test_build_project_src` option in
platformio.ini files to `test_build_src` to get rid of annoying warning
messages.

[PlatformIO changelog](https://docs.platformio.org/en/latest/core/history.html#:~:text=renamed%20the%20%E2%80%9Ctest_build_project_src%E2%80%9D%20project%20configuration%20option%20to%20the%20test_build_src)